### PR TITLE
Fixed the gui exit

### DIFF
--- a/controls-pyqt/exit_program.py
+++ b/controls-pyqt/exit_program.py
@@ -2,9 +2,10 @@ import sys
 from comms import Communications
 
 class Exit_Program:
-    def __init__(self, comm: Communications):
+    def __init__(self, comm: Communications, app):
         self.comms: Communications = comm
+        self.app = app
         
     def Exit(self):
         self.comms.kill_elec_ops()
-        sys.exit()
+        sys.exit(app.exec_())

--- a/controls-pyqt/gui.py
+++ b/controls-pyqt/gui.py
@@ -19,15 +19,14 @@ from command_constants import *
 from comms import Communications
 from exit_program import Exit_Program as ExitProgram
 
-app = QT.QApplication(sys.argv)
-
 
 class MainWindow(QT.QWidget):
-    def __init__(self, mcuobject: MCUInterface, comms: Communications, exit_program: ExitProgram):
+    def __init__(self, mcuobject: MCUInterface, app, comms: Communications, exit_program: ExitProgram):
         super().__init__()
         self.mcu: MCUInterface = mcuobject
         self.comms: Communications = comms
         self.exit_program: ExitProgram = exit_program
+        self.app = app
             
         self.NUM_THRUSTERS = 4
         self.thruster_speed: int = [0] * self.NUM_THRUSTERS

--- a/main.py
+++ b/main.py
@@ -19,14 +19,19 @@ SENSITIVE_PERCENTAGE: int = 50
 def start():
 	app = QApplication(sys.argv)
 	feather = mcu.MCUInterface(PORT,
-                               baud = BAUD_RATE,
-                               close_on_startup = CLOSE_ON_STARTUP,
-                               refresh_rate = REFRESH_RATE,
-                               max_read = MAX_READ)
-	communications = comms.Communications(feather, SENSITIVE_PERCENTAGE, INITIAL_PERCENTAGE)
-	exit = exit_program.Exit_Program(communications)
-	window2 = gui.MainWindow(feather, communications, exit)
+                                baud = BAUD_RATE,
+                                close_on_startup = CLOSE_ON_STARTUP,
+                                refresh_rate = REFRESH_RATE,
+                                max_read = MAX_READ)
+	communications = comms.Communications(feather,
+					      SENSITIVE_PERCENTAGE, 
+					      INITIAL_PERCENTAGE)
+	exit = exit_program.Exit_Program(communications, app)
+	window2 = gui.MainWindow(feather, 
+				 app,
+				 communications, 
+				 exit)
 	window2.setup_ui()
-	sys.exit(app.exec_())
+	#sys.exit(app.exec_())
 
 start()

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import sys
 import comms
 sys.path.insert(0, './controls-pyqt')
 import exit_program
@@ -32,6 +31,5 @@ def start():
 				 communications, 
 				 exit)
 	window2.setup_ui()
-	#sys.exit(app.exec_())
 
 start()


### PR DESCRIPTION
The escape key will now exit the QApplication too, alongside closing the program safely. @fillnye, I tagged you in, so that you can have a look and test it too. If you're fine with it, let me know. @lutet88, please have a look and see if it follows good Python practices and if there might be any problem with the logic of the additions.